### PR TITLE
fix: correct regexp for detecting chrome

### DIFF
--- a/src/utils/detectors/chrome.js
+++ b/src/utils/detectors/chrome.js
@@ -46,7 +46,7 @@ export default class ChromeDetector {
     }
     execSync(
       `${LSREGISTER} -dump` +
-        " | egrep -i '(google chrome\\( canary\\)\\?|chromium).app$'" +
+        ' | grep -E -i \'(google chrome( canary)?|chromium).app$\'' +
         ' | awk \'{$1=""; print $0}\''
     )
       .toString()


### PR DESCRIPTION
Resolves #23

There was older, relevant change (c6068a261d9d5a376fd032eb29ed24925f351202) but I think that one achieved nothing.