### PR TITLE
fix(detection): Chrome detection fails on MacOs Catalina 

### DIFF
--- a/src/utils/detectors/chrome.js
+++ b/src/utils/detectors/chrome.js
@@ -53,7 +53,7 @@ export default class ChromeDetector {
       .split(newLineRegex)
       .forEach((inst) => {
         suffixes.forEach((suffix) => {
-          const execPath = path.join(inst, suffix)
+          const execPath = path.join(inst.trim(), suffix)
           if (this.canAccess(execPath)) {
             installations.push(execPath)
           }

--- a/src/utils/detectors/chrome.js
+++ b/src/utils/detectors/chrome.js
@@ -10,8 +10,6 @@ import isWsl from 'is-wsl'
 import uniq from 'lodash/uniq'
 
 const newLineRegex = /\r?\n/
-// On Catalina paths have suffixes like ` (0xad12)`.
-const pathRegex = /^path:\s+(.+\.app)(?:\s+\(0x[a-f0-9]+\))?$/
 
 /**
  * This class is based on node-get-chrome
@@ -48,17 +46,12 @@ export default class ChromeDetector {
     }
     execSync(`
       ${LSREGISTER} -dump
-      | grep -E -i '(google chrome( canary)?|chromium)\\.app(\\s|$)'
-      | grep -v -E 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'
+      | grep -E -i -o '/.+(google chrome( canary)?|chromium)\\.app(\\s|$)'
+      | grep -E -v 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'
     `)
       .toString()
       .split(newLineRegex)
-      .forEach((line) => {
-        const pathMatch = line.match(pathRegex)
-        if (!pathMatch) {
-          return
-        }
-        const inst = pathMatch[1]
+      .forEach((inst) => {
         suffixes.forEach((suffix) => {
           const execPath = path.join(inst, suffix)
           if (this.canAccess(execPath)) {

--- a/src/utils/detectors/chrome.js
+++ b/src/utils/detectors/chrome.js
@@ -46,9 +46,11 @@ export default class ChromeDetector {
     if (customChromePath) {
       installations.push(customChromePath)
     }
-    execSync(
-      `${LSREGISTER} -dump | grep -E -i '(google chrome( canary)?|chromium)\\.app(\\s|$)'`
-    )
+    execSync(`
+      ${LSREGISTER} -dump
+      | grep -E -i '(google chrome( canary)?|chromium)\\.app(\\s|$)'
+      | grep -v -E 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'
+    `)
       .toString()
       .split(newLineRegex)
       .forEach((line) => {


### PR DESCRIPTION
In Catalina lines returned by OS have a suffix with some hex code in parenthesis. For example:

path:               /Applications/Google Chrome.app (0x1ae4)
path:               /Users/me/Downloads/Google Chrome.app (0xa8c)

Fixed by parsing lines with regexp and ignoring that part of the line.
Switched from `awk` to JS for that job as it's more flexible and easier.