### PR TITLE
fix(detection): Invalid Chrome detection command

### DIFF
--- a/src/utils/detectors/chrome.js
+++ b/src/utils/detectors/chrome.js
@@ -44,11 +44,11 @@ export default class ChromeDetector {
     if (customChromePath) {
       installations.push(customChromePath)
     }
-    execSync(`
-      ${LSREGISTER} -dump
-      | grep -E -i -o '/.+(google chrome( canary)?|chromium)\\.app(\\s|$)'
-      | grep -E -v 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'
-    `)
+    execSync(
+      `${LSREGISTER} -dump` +
+      " | grep -E -i -o '/.+(google chrome( canary)?|chromium)\\.app(\\s|$)'" +
+      " | grep -E -v 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'"
+    )
       .toString()
       .split(newLineRegex)
       .forEach((inst) => {


### PR DESCRIPTION
There must be no newlines in the command string or it will fail executing.